### PR TITLE
Add ente Auth

### DIFF
--- a/yaml/degoogle.yml
+++ b/yaml/degoogle.yml
@@ -1916,6 +1916,12 @@ mobile applications:
       eyes: null
       text: >
         Open-source 2FA for Android. Available on F-Droid.
+    - name: ente Auth
+      url: https://ente.io/auth/
+      repo: https://github.com/ente-io/auth
+      eyes: 5
+      text: >
+        A simple, end-to-end encrypted, open-source authenticator with cloud backups. Apps are available for iOS and Android. From the makers of ente Photos.        
     - name: Authenticator
       url: https://mattrubin.me/authenticator/
       repo: https://github.com/mattrubin/Authenticator


### PR DESCRIPTION
Hey there! As suggested in https://github.com/tycrek/degoogle/pull/485#issuecomment-1431124670, I'm opening a PR to add ente Auth to the list of 2FA apps here.

Some mentions/reviews:

* [New oil - Twitter mention](https://twitter.com/thenewoil1/status/1602077944611995649)
* [Detailed review at zeroclick.xyz](https://zeroclick.xyz/ente-auth)
* [FOSS Android - Mastodon review](https://mstdn.social/@foss_android/109505185418700364)

And here is the original blog post introducing it - https://ente.io/blog/auth/

Thank you!

<!-- If your Pull Request is related to an alternative, make sure there is a corresponding Issue for discussion. -->

| Checklist |   |
| --------- | - |
| **I have read the guidelines in [CONTRIBUTING.md]**   | yes |
| Include my name in [CONTRIBUTORS.md]                  | 🤷 either is fine |
| I am affiliated with this alternative (if applicable) | yes |


### Details
<!-- Optional if details exist in a linked Issue. If that is the case, link to the Issue here. -->


[CONTRIBUTING.md]: ../blob/master/CONTRIBUTING.md
[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
